### PR TITLE
feat: add rate limiting and lockdown CLI

### DIFF
--- a/internal/gate/types.go
+++ b/internal/gate/types.go
@@ -49,6 +49,17 @@ type Engine struct {
 	onRequest    func(*Request) // Callback when new request created
 	totpVerify   func(code string) bool
 	sessionValid func() bool
+
+	// Rate limiting state
+	rateLimiter *RateLimiter
+}
+
+// RateLimiter tracks TOTP attempt rates.
+type RateLimiter struct {
+	mu              sync.Mutex
+	attempts        []time.Time // Recent attempts within window
+	consecutiveFail int         // Consecutive failures
+	lockedUntil     time.Time   // Lockout expiry (zero if not locked)
 }
 
 // Config holds gate engine configuration.


### PR DESCRIPTION
## Summary

Adds rate limiting for TOTP attempts and emergency lockdown mode.

### Rate Limiting
- Max 5 attempts per minute (configurable)
- Auto-lockout after 10 consecutive failures for 15 minutes
- Resets on successful authentication
- Exposed in stats: `rate_limit_locked`, `consecutive_failures`

### Lockdown CLI
```bash
feelgoodbot lockdown           # Emergency: revoke all, block everything
feelgoodbot lockdown lift      # Requires TOTP to restore access
feelgoodbot lockdown status    # Check current state
```

When lockdown activates:
- All active tokens are revoked
- All pending requests are denied
- New gate requests are blocked until lifted

### Testing
- Added `TestRateLimiting` - verifies per-window limits
- Added `TestRateLimitLockout` - verifies consecutive failure lockout
- Added `TestRateLimitResetOnSuccess` - verifies reset on success