### PR TITLE
feat: add version command with build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.buildDate=$(DATE)
+
+.PHONY: build install clean lint test
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o feelgoodbot ./cmd/feelgoodbot
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/feelgoodbot
+
+clean:
+	rm -f feelgoodbot
+
+lint:
+	gofmt -w .
+	go vet ./...
+
+test:
+	go test ./...
+
+# Build for release (stripped, optimized)
+release:
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -trimpath -o feelgoodbot ./cmd/feelgoodbot

--- a/cmd/feelgoodbot/main.go
+++ b/cmd/feelgoodbot/main.go
@@ -21,7 +21,11 @@ import (
 	"github.com/kris-hansen/feelgoodbot/pkg/indicators"
 )
 
-var version = "0.1.0-dev"
+var (
+	version   = "0.1.0-dev"
+	commit    = "unknown"
+	buildDate = "unknown"
+)
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -61,6 +65,22 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(indicatorsCmd)
 	rootCmd.AddCommand(totpCmd)
+	rootCmd.AddCommand(versionCmd)
+}
+
+// version command - show version info
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("feelgoodbot %s\n", version)
+		if commit != "unknown" {
+			fmt.Printf("  commit:  %s\n", commit)
+		}
+		if buildDate != "unknown" {
+			fmt.Printf("  built:   %s\n", buildDate)
+		}
+	},
 }
 
 // init command - create initial baseline


### PR DESCRIPTION
Adds a `feelgoodbot version` subcommand that shows:
- Version string
- Git commit hash
- Build date

Also includes a Makefile with:
- `make build` — build with version info
- `make install` — install to GOBIN
- `make release` — optimized release build
- `make lint` — run gofmt + go vet
- `make test` — run tests

Example output:
```
$ feelgoodbot version
feelgoodbot v0.1.0
  commit:  abc1234
  built:   2026-02-22T18:00:28Z
```