### PR TITLE
feat: add goreleaser + homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,64 @@
+version: 2
+
+project_name: feelgoodbot
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: feelgoodbot
+    main: ./cmd/feelgoodbot
+    binary: feelgoodbot
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.buildDate={{.Date}}
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+brews:
+  - name: feelgoodbot
+    repository:
+      owner: kris-hansen
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://feelgoodbot.com"
+    description: "Malware detection for macOS - know when you've been compromised"
+    license: "MIT"
+    install: |
+      bin.install "feelgoodbot"
+    test: |
+      system "#{bin}/feelgoodbot", "version"
+
+release:
+  github:
+    owner: kris-hansen
+    name: feelgoodbot
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
## Summary
Adds automated release pipeline with Homebrew support.

## Changes
- `.goreleaser.yaml` — builds for darwin/linux on amd64/arm64
- `.github/workflows/release.yml` — triggers on version tags
- Created `kris-hansen/homebrew-tap` repo

## Setup Required
Add `HOMEBREW_TAP_TOKEN` secret to the repo:
1. Create a PAT with `repo` scope at https://github.com/settings/tokens
2. Add as secret: Settings → Secrets → Actions → New secret

## Usage

**Release:**
```bash
git tag v0.1.0
git push origin v0.1.0
```

**Install via Homebrew:**
```bash
brew tap kris-hansen/tap
brew install feelgoodbot
```

**Verify:**
```bash
feelgoodbot version
```